### PR TITLE
Fix broken gevent dep for python26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ tests_require = [
 ]
 
 if sys.version_info < (2, 7):
-    install_requires.append('argparse>=0.8')
+     install_requires.extend([
+       'argparse>=0.8',
+       'gevent<1.2'])
 
 setup(
     name="wal-e",

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ tests_require = [
 ]
 
 if sys.version_info < (2, 7):
-     install_requires.extend([
-       'argparse>=0.8',
-       'gevent<1.2'])
+    install_requires.extend([
+      'argparse>=0.8',
+      'gevent<1.2'])
 
 setup(
     name="wal-e",


### PR DESCRIPTION
gevent 1.2 is not compatible with python 2.6, adding a version cap.